### PR TITLE
Add custom emojis to deep dives embed

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -5,7 +5,7 @@ from logging import Formatter, FileHandler, Logger
 from discord import app_commands, File, Embed, Intents, Client
 from dotenv import load_dotenv
 from util.constants import ERROR_RESPONSE_TEXT
-from model.deepdives import DeepDives, Type
+from model.deepdives import DeepDives, DiveType
 from model.ui import ButtonView
 from service.drg import DRGService
 from util.embed import embed_deep_dive, embed_trivia, embed_help
@@ -89,7 +89,7 @@ async def ping_cmd(ctx):
 @tree.command(name="deep-dive",
               description="Get weekly Deep Dive details")
 @app_commands.describe(variant="Which Deep Dive(s) to get details for")
-async def deep_dive_cmd(ctx, variant: Type = Type.ALL):
+async def deep_dive_cmd(ctx, variant: DiveType = DiveType.ALL):
     try:
         logger.info(f'Recieved /deep-dive command with type={variant.name}')
         await ctx.response.defer()

--- a/src/model/deepdives.py
+++ b/src/model/deepdives.py
@@ -4,7 +4,7 @@ import emoji
 from pydantic import BaseModel
 
 
-class Type(str, Enum):
+class DiveType(str, Enum):
     ALL = "All"
     DEEP_DIVE = "Deep Dive"
     ELITE_DEEP_DIVE = "Elite Deep Dive"
@@ -69,7 +69,7 @@ class Stage(BaseModel):
 
 
 class Variant(BaseModel):
-    type: Type
+    type: DiveType
     name: str
     biome: Biome
     seed: int
@@ -90,7 +90,7 @@ class DeepDives(BaseModel):
     endTime: str
     variants: list[Variant]
 
-    def get_variant(self, type: Type) -> Variant:
+    def get_variant(self, type: DiveType) -> Variant:
         for variant in self.variants:
             if variant.type == type:
                 return variant

--- a/src/tests/service/test_drg.py
+++ b/src/tests/service/test_drg.py
@@ -1,6 +1,6 @@
 import pytest
 import json
-from model.deepdives import Anomaly, Biome, DeepDives, Stage, Type, Variant, Warning
+from model.deepdives import Anomaly, Biome, DeepDives, Stage, DiveType, Variant, Warning
 from model.salutes import Salutes
 from model.trivia import Trivia
 from service.drg import DRGService
@@ -96,9 +96,9 @@ def test_get_deepdives_success(requests_mock, drg_service):
     assert deepdives.endTime == "2023-05-18T11:00:00Z"
     assert len(deepdives.variants) == 2
     
-    dd: Variant = deepdives.get_variant(Type.DEEP_DIVE)
+    dd: Variant = deepdives.get_variant(DiveType.DEEP_DIVE)
     assert isinstance(dd, Variant)
-    assert dd.type == Type.DEEP_DIVE
+    assert dd.type == DiveType.DEEP_DIVE
     assert dd.name == "Corroded Reserve"
     assert dd.biome == Biome.RADIOACTIVE_EXCLUSION_ZONE
     assert dd.seed == 259722398
@@ -123,9 +123,9 @@ def test_get_deepdives_success(requests_mock, drg_service):
     assert dd_stage3.anomaly == None
     assert dd_stage3.warning == Warning.LOW_OXYGEN
 
-    edd: Variant = deepdives.get_variant(Type.ELITE_DEEP_DIVE)
+    edd: Variant = deepdives.get_variant(DiveType.ELITE_DEEP_DIVE)
     assert isinstance(edd, Variant)
-    assert edd.type == Type.ELITE_DEEP_DIVE
+    assert edd.type == DiveType.ELITE_DEEP_DIVE
     assert edd.name == "Naked Burrow"
     assert edd.biome == Biome.SALT_PITS
     assert edd.seed == 797585550

--- a/src/util/embed.py
+++ b/src/util/embed.py
@@ -1,16 +1,16 @@
 import discord
-from model.deepdives import DeepDives, Type, Variant
+from model.deepdives import DeepDives, DiveType, Variant
 from util.date import prettify_datetime
 
 
-def embed_deep_dive(thumbnail: discord.File, deep_dives: DeepDives, type: Type):
+def embed_deep_dive(thumbnail: discord.File, deep_dives: DeepDives, type: DiveType):
     start_date = prettify_datetime(deep_dives.startTime)
     embed = discord.Embed(title=f'Weekly Deep Dives ({start_date})', color=0xFDA50F)
     embed.set_thumbnail(url=f'attachment://{thumbnail.filename}')
 
     # Deep Dive
     if type in (type.ALL, type.DEEP_DIVE):
-        dd: Variant = deep_dives.get_variant(Type.DEEP_DIVE)
+        dd: Variant = deep_dives.get_variant(DiveType.DEEP_DIVE)
         embed.add_field(name=str(dd), value='', inline=False)
         for stage in dd.stages:
             embed.add_field(name=f'Stage {str(stage.id)}', value=str(stage), inline=True)
@@ -21,7 +21,7 @@ def embed_deep_dive(thumbnail: discord.File, deep_dives: DeepDives, type: Type):
 
     # Elite Deep Dive
     if type in (type.ALL, type.ELITE_DEEP_DIVE):
-        edd: Variant = deep_dives.get_variant(Type.ELITE_DEEP_DIVE)
+        edd: Variant = deep_dives.get_variant(DiveType.ELITE_DEEP_DIVE)
         embed.add_field(name=str(edd), value='', inline=False)
         for stage in edd.stages:
             embed.add_field(name=f'Stage {str(stage.id)}', value=str(stage), inline=True)


### PR DESCRIPTION
## Summary

Please note that this PR is still a Draft

## Type of Change

Please select all that apply:

- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation Update

## Included Changes

[x] Rename`Type` enum to `DiveType` - just a better name
[x] Move `primary` and `secondary` deep dive stages to their own object `Mission` with type property built-in
[x] Move all emojis generation to `get_emoji` (this function should probably be in some util file but it causes issues with circular imports)
[ ] Add custom emojis to all objectives, anomalies and warnings
